### PR TITLE
allowEmpty on Required and Optional annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v2.1.1
 
-* bug fixes
+* Added the ability for Required and Optional parameter annotations to specify whether they allow blank strings. If not, they will be considered errors.
 
 # v2.1.0
 

--- a/src/main/java/com/v5analytics/webster/annotations/Optional.java
+++ b/src/main/java/com/v5analytics/webster/annotations/Optional.java
@@ -17,5 +17,7 @@ public @interface Optional {
 
     String defaultValue() default NOT_SET;
 
+    boolean allowEmpty() default true;
+
     Class<? extends ParameterValueConverter> parameterValueConverter() default DefaultParameterValueConverter.class;
 }

--- a/src/main/java/com/v5analytics/webster/annotations/Required.java
+++ b/src/main/java/com/v5analytics/webster/annotations/Required.java
@@ -13,5 +13,7 @@ import java.lang.annotation.Target;
 public @interface Required {
     String name();
 
+    boolean allowEmpty() default true;
+
     Class<? extends ParameterValueConverter> parameterValueConverter() default DefaultParameterValueConverter.class;
 }

--- a/src/main/java/com/v5analytics/webster/parameterProviders/OptionalParameterProvider.java
+++ b/src/main/java/com/v5analytics/webster/parameterProviders/OptionalParameterProvider.java
@@ -2,15 +2,20 @@ package com.v5analytics.webster.parameterProviders;
 
 import com.v5analytics.webster.HandlerChain;
 import com.v5analytics.webster.ParameterValueConverter;
+import com.v5analytics.webster.WebsterException;
+import com.v5analytics.webster.annotations.Optional;
+import com.v5analytics.webster.utils.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class OptionalParameterProvider<T> extends ValueParameterProvider<T> {
     private final String defaultValue;
+    private final Optional annotation;
 
-    public OptionalParameterProvider(Class<?> parameterType, String parameterName, ParameterValueConverter parameterValueConverter, String defaultValue) {
-        super(parameterType, parameterName, parameterValueConverter);
+    public OptionalParameterProvider(Class<?> parameterType, Optional annotation, ParameterValueConverter parameterValueConverter, String defaultValue) {
+        super(parameterType, annotation.name(), parameterValueConverter);
+        this.annotation = annotation;
         this.defaultValue = defaultValue;
     }
 
@@ -22,6 +27,10 @@ public class OptionalParameterProvider<T> extends ValueParameterProvider<T> {
                 value = null;
             } else {
                 value = new String[]{defaultValue};
+            }
+        } else {
+            if (!annotation.allowEmpty() && StringUtils.containsAnEmpty(value)) {
+                throw new WebsterException(String.format("Parameter: '%s' may not be or contain blanks in the request", getParameterName()));
             }
         }
         return toParameterType(value);

--- a/src/main/java/com/v5analytics/webster/parameterProviders/OptionalParameterProviderFactory.java
+++ b/src/main/java/com/v5analytics/webster/parameterProviders/OptionalParameterProviderFactory.java
@@ -21,7 +21,7 @@ public class OptionalParameterProviderFactory<T> extends ValueParameterProviderF
         }
         ParameterValueConverter parameterValueConverter = createParameterValueConverter(optionalAnnotation.parameterValueConverter());
         String defaultValue = getDefaultValueFromAnnotation(optionalAnnotation);
-        return new OptionalParameterProvider<>(parameterType, optionalAnnotation.name(), parameterValueConverter, defaultValue);
+        return new OptionalParameterProvider<>(parameterType, optionalAnnotation, parameterValueConverter, defaultValue);
     }
 
     private String getDefaultValueFromAnnotation(Optional optionalAnnotation) {

--- a/src/main/java/com/v5analytics/webster/parameterProviders/RequiredParameterProvider.java
+++ b/src/main/java/com/v5analytics/webster/parameterProviders/RequiredParameterProvider.java
@@ -3,13 +3,18 @@ package com.v5analytics.webster.parameterProviders;
 import com.v5analytics.webster.HandlerChain;
 import com.v5analytics.webster.ParameterValueConverter;
 import com.v5analytics.webster.WebsterException;
+import com.v5analytics.webster.annotations.Required;
+import com.v5analytics.webster.utils.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class RequiredParameterProvider<T> extends ValueParameterProvider<T> {
-    protected RequiredParameterProvider(Class<?> parameterType, String parameterName, ParameterValueConverter parameterValueConverter) {
-        super(parameterType, parameterName, parameterValueConverter);
+    private final Required annotation;
+
+    protected RequiredParameterProvider(Class<?> parameterType, Required annotation, ParameterValueConverter parameterValueConverter) {
+        super(parameterType, annotation.name(), parameterValueConverter);
+        this.annotation = annotation;
     }
 
     @Override
@@ -17,6 +22,9 @@ public class RequiredParameterProvider<T> extends ValueParameterProvider<T> {
         String[] value = getParameterOrAttribute(request);
         if (value == null) {
             throw new WebsterException(String.format("Parameter: '%s' is required in the request", getParameterName()));
+        }
+        if (!annotation.allowEmpty() && StringUtils.containsAnEmpty(value)) {
+            throw new WebsterException(String.format("Parameter: '%s' may not be blank or contain blanks in the request", getParameterName()));
         }
         T result = toParameterType(value);
         if (!isValueValid(result)) {
@@ -39,6 +47,8 @@ public class RequiredParameterProvider<T> extends ValueParameterProvider<T> {
                 return false;
             }
         }
+
         return true;
     }
+
 }

--- a/src/main/java/com/v5analytics/webster/parameterProviders/RequiredParameterProviderFactory.java
+++ b/src/main/java/com/v5analytics/webster/parameterProviders/RequiredParameterProviderFactory.java
@@ -20,7 +20,7 @@ public class RequiredParameterProviderFactory<T> extends ValueParameterProviderF
             throw new WebsterException("Could not find required annotation");
         }
         ParameterValueConverter parameterValueConverter = createParameterValueConverter(requiredAnnotation.parameterValueConverter());
-        return new RequiredParameterProvider<>(parameterType, requiredAnnotation.name(), parameterValueConverter);
+        return new RequiredParameterProvider<>(parameterType, requiredAnnotation, parameterValueConverter);
     }
 
     private static Required getRequiredAnnotation(Annotation[] annotations) {

--- a/src/main/java/com/v5analytics/webster/utils/StringUtils.java
+++ b/src/main/java/com/v5analytics/webster/utils/StringUtils.java
@@ -1,0 +1,16 @@
+package com.v5analytics.webster.utils;
+
+public class StringUtils {
+    public static boolean isEmpty(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+
+    public static boolean containsAnEmpty(String[] strings) {
+        for (String str : strings) {
+            if (StringUtils.isEmpty(str)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Added the ability for Required and Optional parameter annotations to specify whether they allow blank strings. If not, they will be considered errors.
