### PR TITLE
make http request available to ResultWriterBase subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.1.3
 
 * change access logging to use `com.v5analytics.webster.App.ACCESS_LOG` at `DEBUG` level to allow granular control over access logging
+* make HttpServletRequest available to ResultWriterBase subclasses
 
 # v2.1.2
 

--- a/src/main/java/com/v5analytics/webster/resultWriters/ResultWriterBase.java
+++ b/src/main/java/com/v5analytics/webster/resultWriters/ResultWriterBase.java
@@ -38,10 +38,11 @@ public class ResultWriterBase implements ResultWriter {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
-        writeResult(response, result);
+        writeResult(request, response, result);
     }
 
-    protected void writeResult(HttpServletResponse response, Object result) throws IOException {
+    @SuppressWarnings("unused")
+    protected void writeResult(HttpServletRequest request, HttpServletResponse response, Object result) throws IOException {
         response.getOutputStream().write(getResultBytes(result));
     }
 


### PR DESCRIPTION
This is needed by Visallo for enforcing access control.
