### PR TITLE
Add ability to set handler to be used when no routes match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.3.0
+
+* add ability to set the file handler used when no routes are matched
+
 # v2.2.1
 
 * add additional HTTP methods HEAD, OPTIONS, TRACE, CONNECT

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,12 @@
-Copyright 2015 V5 Analytics
+Copyright 2017 Visallo, LLC
 
 This product includes software developed by
-V5 Analytics LLC (http://www.v5analytics.com/)
+Visallo, LLC (https://visallo.com/)
+
+Copyright 2015 V5 Analytics, LLC
+
+This product includes software originally developed by
+V5 Analytics, LLC (http://www.v5analytics.com/)
 
 
 Copyright 2013 Altamira Technologies Corporation

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-webster [![Build Status](https://travis-ci.org/v5analytics/webster.svg?branch=master)](https://travis-ci.org/v5analytics/webster)
+webster [![Build Status](https://travis-ci.org/visallo/webster.svg?branch=master)](https://travis-ci.org/visallo/webster)
 ======
 
 Minimal web framework, implemented in Java, resembling [node.js](https://github.com/joyent/node)+[express](https://github.com/visionmedia/express).
 
 License
 -------
-Copyright 2015 V5 Analytics LLC<br>
+Copyright 2017 Visallo, LLC<br>
+Copyright 2015 V5 Analytics, LLC<br>
 Copyright 2013 Altamira Technologies Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     
     <groupId>com.v5analytics.webster</groupId>
     <artifactId>webster</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
 
     <name>Webster: Minimalist Web Framework</name>
     <inceptionYear>2014</inceptionYear>

--- a/src/test/java/com/v5analytics/webster/AppTest.java
+++ b/src/test/java/com/v5analytics/webster/AppTest.java
@@ -8,14 +8,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -25,9 +23,9 @@ public class AppTest {
     private RequestResponseHandler handler;
     private HttpServletRequest request;
     private HttpServletResponse response;
-    private RequestDispatcher requestDispatcher;
     private ServletContext servletContext;
     private App app;
+    private RequestResponseHandler missingRouteHandler;
 
     @Before
     public void before() {
@@ -48,9 +46,10 @@ public class AppTest {
         handler = mock(RequestResponseHandler.class);
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
-        requestDispatcher = mock(RequestDispatcher.class);
         servletContext = mock(ServletContext.class);
         app = new App(servletContext);
+        missingRouteHandler = mock(RequestResponseHandler.class);
+        app.getRouter().setMissingRouteHandler(missingRouteHandler);
         when(request.getAttribute(App.WEBSTER_APP_ATTRIBUTE_NAME)).thenReturn(app);
     }
 
@@ -179,9 +178,8 @@ public class AppTest {
         when(request.getMethod()).thenReturn("POST");
         when(request.getRequestURI()).thenReturn(path);
         when(request.getContextPath()).thenReturn("");
-        when(servletContext.getNamedDispatcher(anyString())).thenReturn(requestDispatcher);
         app.handle(request, response);
-        verify(requestDispatcher).forward(any(HttpServletRequest.class), any(HttpServletResponse.class));
+        verify(missingRouteHandler).handle(eq(request), eq(response), any(HandlerChain.class));
     }
 
     @Test


### PR DESCRIPTION
With this PR you can now set the handler to be used when no routes are matched. By default it uses the StaticFileHandler.