### PR TITLE
Stateless CSRF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     
     <groupId>com.v5analytics.webster</groupId>
     <artifactId>webster</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>Webster: Minimalist Web Framework</name>
     <inceptionYear>2014</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     
     <groupId>com.v5analytics.webster</groupId>
     <artifactId>webster</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
 
     <name>Webster: Minimalist Web Framework</name>
     <inceptionYear>2014</inceptionYear>

--- a/src/main/java/com/v5analytics/webster/handlers/CSRFHandler.java
+++ b/src/main/java/com/v5analytics/webster/handlers/CSRFHandler.java
@@ -3,46 +3,67 @@ package com.v5analytics.webster.handlers;
 import com.v5analytics.webster.HandlerChain;
 import com.v5analytics.webster.RequestResponseHandler;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
 public class CSRFHandler implements RequestResponseHandler {
-    public static final String CSRF_TOKEN_ATTR = "webster.csrf.token";
+    public static final String CSRF_COOKIE_NAME = "CSRF";
 
     private final String tokenRequestParameterName;
     private final String tokenRequestHeaderName;
 
-    public static String getSavedToken(HttpServletRequest request) {
-        return getSavedToken(request, false);
+    public static String getSavedToken(HttpServletRequest request, HttpServletResponse response) {
+        return getSavedToken(request, response, false);
     }
 
-    public static String getSavedToken(HttpServletRequest request, boolean createTokenIfMissing) {
-        HttpSession session = request.getSession(createTokenIfMissing);
-        if (session == null) {
+    public static String getSavedToken(HttpServletRequest request, HttpServletResponse response, boolean createTokenIfMissing) {
+        String token = null;
+        Cookie tokenCookie = getTokenCookie(request);
+
+        if (tokenCookie != null) {
+            token = tokenCookie.getValue();
+        } else if (tokenCookie == null && createTokenIfMissing) {
+            token = resetSavedToken(request, response);
+        }
+
+        return token;
+    }
+
+    private static Cookie getTokenCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
             return null;
         }
 
-        String token = (String) session.getAttribute(CSRF_TOKEN_ATTR);
-        if (token == null && createTokenIfMissing) {
-            token = resetSavedToken(request);
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(CSRFHandler.CSRF_COOKIE_NAME)) {
+                return cookie;
+            }
         }
 
-        return token;
+        return null;
     }
 
-    private static String resetSavedToken(HttpServletRequest request) {
+    private static String resetSavedToken(HttpServletRequest request, HttpServletResponse response) {
         String token = new BigInteger(120, new SecureRandom()).toString(32);
-        request.getSession().setAttribute(CSRF_TOKEN_ATTR, token);
+        Cookie tokenCookie = new Cookie(CSRF_COOKIE_NAME, token);
+        tokenCookie.setPath("/");
+        tokenCookie.setMaxAge(-1);
+        tokenCookie.setSecure(true);
+        tokenCookie.setHttpOnly(true);
+        response.addCookie(tokenCookie);
         return token;
     }
 
-    private static void clearSavedToken(HttpServletRequest request) {
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            request.getSession().removeAttribute(CSRF_TOKEN_ATTR);
+    private static void clearSavedToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = getTokenCookie(request);
+        if (cookie != null) {
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
         }
     }
 
@@ -59,7 +80,7 @@ public class CSRFHandler implements RequestResponseHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, HandlerChain chain) throws Exception {
         if (request.getMethod().equals("GET")) {
-            verifyTokenAbsence(request);
+            verifyTokenAbsence(request, response);
         } else {
             verifyToken(request, response);
         }
@@ -68,23 +89,23 @@ public class CSRFHandler implements RequestResponseHandler {
 
     private void verifyToken(HttpServletRequest request, HttpServletResponse response) throws TokenException {
         String tokenFromRequest = getTokenFromRequest(request);
-        String storedToken = CSRFHandler.getSavedToken(request);
+        String storedToken = CSRFHandler.getSavedToken(request, response);
         if (tokenFromRequest == null) {
             throw new TokenException("CSRF token not found in request parameter " + this.tokenRequestParameterName);
         }
         if (storedToken == null) {
-            throw new TokenException("CSRF token has not been set in the user's session");
+            throw new TokenException("CSRF token cookie not found");
         }
         if (!tokenFromRequest.equals(storedToken)) {
             throw new TokenException("CSRF token from request parameter " + this.tokenRequestParameterName
-                    + " does not match the one stored in the user's session");
+                    + " does not match the one from the user's CSRF cookie");
         }
     }
 
-    private void verifyTokenAbsence(HttpServletRequest request) throws TokenException {
+    private void verifyTokenAbsence(HttpServletRequest request, HttpServletResponse response) throws TokenException {
         String tokenFromRequest = getTokenFromRequest(request);
         if (tokenFromRequest != null) {
-            CSRFHandler.resetSavedToken(request);
+            CSRFHandler.resetSavedToken(request, response);
             throw new TokenException("CSRF token found in a " + request.getMethod() + " request. Token has been reset");
         }
     }

--- a/src/main/java/com/v5analytics/webster/handlers/SessionProhibitionHandler.java
+++ b/src/main/java/com/v5analytics/webster/handlers/SessionProhibitionHandler.java
@@ -1,0 +1,66 @@
+package com.v5analytics.webster.handlers;
+
+import com.v5analytics.webster.HandlerChain;
+import com.v5analytics.webster.RequestResponseHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+public class SessionProhibitionHandler implements RequestResponseHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, HandlerChain chain) throws Exception {
+        chain.next(new SessionProhibitionHttpRequestWrapper(request), response);
+    }
+
+    private class SessionProhibitionHttpRequestWrapper extends HttpServletRequestWrapper {
+        public static final String ERROR_MSG = "javax.servlet.http.HttpSession use is prohibited";
+
+        public SessionProhibitionHttpRequestWrapper(HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public HttpSession getSession(boolean create) {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public HttpSession getSession() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromUrl() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+
+        @Override
+        public String changeSessionId() {
+            throw new UnsupportedOperationException(ERROR_MSG);
+        }
+    }
+
+}

--- a/src/test/java/com/v5analytics/webster/handlers/SessionProhibitionHandlerTest.java
+++ b/src/test/java/com/v5analytics/webster/handlers/SessionProhibitionHandlerTest.java
@@ -1,0 +1,95 @@
+package com.v5analytics.webster.handlers;
+
+import com.v5analytics.webster.HandlerChain;
+import com.v5analytics.webster.RequestResponseHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(JUnit4.class)
+public class SessionProhibitionHandlerTest {
+    private SessionProhibitionHandler handler;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+
+    @Before
+    public void setup() {
+        handler = new SessionProhibitionHandler();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetSessionIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.getSession();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetSessionWithArgIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.getSession(true);
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetRequestSessionIdIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.getRequestedSessionId();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsRequestedSessionIdValidIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.isRequestedSessionIdValid();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsRequestedSessionIdFromCookieIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.isRequestedSessionIdFromCookie();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsRequestedSessionIdFromUrlIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.isRequestedSessionIdFromUrl();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsRequestedSessionIdFromURLIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.isRequestedSessionIdFromURL();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testChangeSessionIdIsProhibited() throws Exception {
+        RequestResponseHandler nextHandler = (request, response, chain) -> {
+            request.changeSessionId();
+        };
+        handler.handle(request, response, chain(nextHandler));
+    }
+
+    public HandlerChain chain(RequestResponseHandler handler) {
+        return new HandlerChain(new RequestResponseHandler[] { handler });
+    }
+}


### PR DESCRIPTION
Change CSRF implementation to avoid server side state. Also add a handler that prohibits the use of the `HttpSession`.